### PR TITLE
MX 7.6 Update

### DIFF
--- a/src/FileDocumentViewer/widget/FileDocumentViewer.js
+++ b/src/FileDocumentViewer/widget/FileDocumentViewer.js
@@ -125,7 +125,7 @@ require( [
             if (this._contextObj === null || this._contextObj.get("Name") === null) {
                 return require.toUrl("FileDocumentViewer/widget/ui/error.html");
             } else {
-                return "file?target=window&guid=" + this._contextObj.getGuid() + "&csrfToken=" + mx.session.getCSRFToken() + "&time=" + Date.now();
+                return "file?target=window&guid=" + this._contextObj.getGuid() + "&csrfToken=" + mx.session.sessionData.csrftoken + "&time=" + Date.now();
             }
         },
 


### PR DESCRIPTION
In MX 7.6, line 128 throws an error due to a deprecated function call.  In order to eliminate this error, I replaced 
mx.session.getCSRFToken()
with
mx.session.sessionData.csrftoken